### PR TITLE
ci: add minimal GitHub Actions test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then sed 's/^mysql-python$/mysqlclient/' requirements.txt > /tmp/requirements-ci.txt && pip install -r /tmp/requirements-ci.txt; fi
           if [ -f pyproject.toml ]; then pip install .; fi
           pip install pytest
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install .; fi
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then sed 's/^mysql-python$/mysqlclient/' requirements.txt > /tmp/requirements-ci.txt && pip install -r /tmp/requirements-ci.txt; fi
+          if [ -f requirements.txt ]; then tr -d '\r' < requirements.txt | sed -E 's/^mysql-python[[:space:]]*$/mysqlclient/' > /tmp/requirements-ci.txt && pip install -r /tmp/requirements-ci.txt; fi
           if [ -f pyproject.toml ]; then pip install .; fi
           pip install pytest
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,5 @@ jobs:
           if [ -f pyproject.toml ]; then pip install .; fi
           pip install pytest
       - name: Run tests
-        run: pytest -q
+        run: |
+          pytest -q || test $? -eq 5


### PR DESCRIPTION
## Summary
Adds a minimal GitHub Actions workflow to run tests for this repository.

- Detected stack: **python**
- Workflow path: 
- Conservative defaults only; no runtime code changes.

## Why
This repository did not have a GitHub Actions workflow that runs tests.

## Notes
- Triggered on push to / and pull requests.
- Kept intentionally minimal and non-breaking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal GitHub Actions workflow to run pytest on pushes to main/master and on pull requests.
Uses Python 3.11 on ubuntu-latest, installs deps from requirements.txt or pyproject (strips CRLF; swaps mysql-python→mysqlclient), then runs tests.

<sup>Written for commit 78ab4cecfd9ac5b37047a8fdc8b68fa8252d1f23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated testing workflow to execute on pull requests and pushes to main/master branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->